### PR TITLE
REQUEST_SCHEME issues on non-apache webservers

### DIFF
--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -422,8 +422,19 @@ if (!defined('__CSRF_PROTECTOR__')) {
 		 */
 		private static function getCurrentUrl()
 		{
-			return $_SERVER['REQUEST_SCHEME'] .'://'
-				.$_SERVER['HTTP_HOST'] .$_SERVER['PHP_SELF'];
+			$request_scheme = 'https';
+
+			if (isset($_SERVER['REQUEST_SCHEME'])) {
+				$request_scheme = $_SERVER['REQUEST_SCHEME'];
+			} else {
+				if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+					$request_scheme = 'https';
+				} else {
+					$request_scheme = 'http';
+				}
+			}
+
+			return $request_scheme . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
 		}
 
 		/*


### PR DESCRIPTION
The REQUEST_SCHEME isn't guaranteed to exist. If it doesn't lets use other means to find it. Here's some discussion on the matter:

https://stackoverflow.com/questions/18008135/is-serverrequest-scheme-reliable

It's worth noting that older versions of apache may also be missing this key.