### PR TITLE
add support for random_bytes and openssl_random_pseudo_bytes

### DIFF
--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -295,7 +295,11 @@ if (!defined('__CSRF_PROTECTOR__')) {
 
 			//#todo - if $length > 128 throw exception 
 
-			if (function_exists("hash_algos") && in_array("sha512", hash_algos())) {
+			if (function_exists("random_bytes")) {
+				$token = base64_encode(random_bytes(96));
+			} else if (function_exists("openssl_random_pseudo_bytes")) {
+				$token = base64_encode(openssl_random_pseudo_bytes(96));
+			} else if (function_exists("hash_algos") && in_array("sha512", hash_algos())) {
 				$token = hash("sha512", mt_rand(0, mt_getrandmax()));
 			} else {
 				$token = '';


### PR DESCRIPTION
`random_bytes` and `openssl_random_pseudo_bytes` use `/dev/urandom` and `CryptGenRandom` and are better than `mt_rand` in randomness. `random_bytes` can be used in PHP 7.0 alpha. I didn't see any issue in the [result](https://gist.github.com/masakielastic/76ec50728d259626cf14) of benchmark.