### PR TITLE
Adding autoload to the Composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,8 @@
     "license": "APACHE",
     "require-dev": {
         "satooshi/php-coveralls": ">=0.6"
+    },
+    "autoload": {
+        "classmap": ["libs/csrf/"]
     }
 }


### PR DESCRIPTION
We can specify the directory with the file to load in the Composer file. The [Composer's doc](https://getcomposer.org/doc/01-basic-usage.md#autoloading) says:

```
For libraries that specify autoload information, Composer generates a vendor/autoload.php file. You can simply include this file and you will get autoloading for free.

require __DIR__ . '/vendor/autoload.php';
```

It makes it easier for the dev using Composer to include the library.