### PR TITLE
secureCookie configuration option for cookie secure flag

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -16,5 +16,6 @@ CSRFProtector configuration
  - `jsPath`: location of the js file **relative** to `config.php`. <br>**Default:** `../js/csrfprotector.js`
  - `jsUrl`: **Absolute url** of the js file. (See [Setting up](https://github.com/mebjas/CSRF-Protector-PHP/wiki/Setting-up-CSRF-Protector-PHP-in-your-web-application) for more information)
  - `tokenLength`: length of csrfp token, Default `10`
+ - `secureCookie`: sets the "secure" HTTPS flag on the cookie. <br>**Default: `false`**
  - `disabledJavascriptMessage`: messaged to be shown if js is disabled (string)
  - `verifyGetFor`: regex rules for those urls for which csrfp validation should be enabled for `GET` requests also. (View [verifyGetFor rules](https://github.com/mebjas/CSRF-Protector-PHP/wiki/verifyGetFor-rules) for more information)

--- a/libs/config.sample.php
+++ b/libs/config.sample.php
@@ -19,6 +19,7 @@ return array(
 	"jsPath" => "../js/csrfprotector.js",
 	"jsUrl" => "",
 	"tokenLength" => 10,
+	"secureCookie" => false,
 	"disabledJavascriptMessage" => "This site attempts to protect users against <a href=\"https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29\">
 	Cross-Site Request Forgeries </a> attacks. In order to do so, you must have JavaScript enabled in your web browser otherwise this site will fail to work correctly for you.
 	 See details of your web browser for how to enable JavaScript.",

--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -325,7 +325,10 @@ if (!defined('__CSRF_PROTECTOR__')) {
 			//set token to cookie for client side processing
 			setcookie(self::$config['CSRFP_TOKEN'], 
 				$token, 
-				time() + self::$cookieExpiryTime);
+				time() + self::$cookieExpiryTime,
+				'',
+				'',
+				(array_key_exists('secureCookie', self::$config) ? (bool)self::$config['secureCookie'] : false));
 		}
 
 		/*

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -15,6 +15,10 @@ class csrfp_wrapper extends csrfprotector
         self::$requestType = $type;
     }
 
+    /**
+     * Function to check for a string value anywhere within HTTP response headers
+     * Returns true on first match of $needle in header names or values
+     */
     public static function checkHeader($needle)
     {
         $haystack = xdebug_get_headers();
@@ -25,6 +29,10 @@ class csrfp_wrapper extends csrfprotector
         return false;
     }
 
+    /**
+     * Function to return the string value of the last response header
+     * identified by name $needle
+     */
     public static function getHeaderValue($needle)
     {
         $haystack = xdebug_get_headers();

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -105,13 +105,20 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][1]));
     }
 
+    /**
+     * test secure flag is set in the token cookie when requested
+     */
     public function testSecureCookie()
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SESSION[csrfprotector::$config['CSRFP_TOKEN']] = array('123abcd');
 
+        csrfprotector::$config['secureCookie'] = false;
+        csrfprotector::refreshToken();
+        $this->assertNotRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
+
         csrfprotector::$config['secureCookie'] = true;
-        csrfprotector::refreshToken(); //will create new session and cookies
+        csrfprotector::refreshToken();
         $this->assertRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
     }
 


### PR DESCRIPTION
Related to #54 this adds a configurable option to set a secure cookie flag. In the issue we discussed naming it `httpsOnly` but that may cause confusion with the `httpOnly` cookie option. It is instead named `secureCookie` but is easily changed.

It has been added with a `false` value in the example config, and defaults to `false` if omitted from the config.

Adding a test required also creating a helper method to retrieve header string values to match in assertions.  According to the `setcookie()` docs, PHP will only set the secure flag if HTTPS is actually present, so the tests explicitly set `$_SERVER['HTTPS'] = on`. Accordingly that has been nulled out in the `setUp()` method.
