### PR TITLE
Use random_bytes if available, drop SHA-512

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
 matrix:
     allow_failures:
     - php: nightly
-    - php: hhvm
 
 os:
   - linux
@@ -31,6 +30,7 @@ before_script:
 
 script:
  - mkdir -p build/logs
+ - if [[ "$TRAVIS_PHP_VERSION" =~ '^hhvm' ]]; then echo 'xdebug.enable = On' >> /etc/hhvm/php.ini; fi
  - phpunit --stderr --coverage-clover build/logs/clover.xml
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 
 script:
  - mkdir -p build/logs
- - if [[ "$TRAVIS_PHP_VERSION" =~ '^hhvm' ]]; then echo 'xdebug.enable = On' >> /etc/hhvm/php.ini; fi
+ - if [ $(phpenv version-name) = 'hhvm' ]; then echo 'xdebug.enable = On' >> ~/.phpenv/versions/hhvm/etc/php.ini; fi
  - phpunit --stderr --coverage-clover build/logs/clover.xml
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
 matrix:
     allow_failures:
     - php: nightly
+    - php: hhvm
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 
 script:
  - mkdir -p build/logs
- - if [ $(phpenv version-name) = 'hhvm' ]; then echo 'xdebug.enable = On' >> ~/.phpenv/versions/hhvm/etc/php.ini; fi
+ - if [ $(phpenv version-name) = 'hhvm' ]; then echo 'xdebug.enable=1' >> /etc/hhvm/php.ini; fi
  - phpunit --stderr --coverage-clover build/logs/clover.xml
 
 after_script:

--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -354,7 +354,7 @@ if (!defined('__CSRF_PROTECTOR__')) {
 		public static function generateAuthToken()
 		{
 			// todo - make this a member method / configurable
-			$randLength = 32;
+			$randLength = 64;
 			
 			//if config tokenLength value is 0 or some non int
 			if (intval(self::$config['tokenLength']) == 0) {
@@ -363,10 +363,10 @@ if (!defined('__CSRF_PROTECTOR__')) {
 
 			//#todo - if $length > 128 throw exception 
 
-			if (function_exists("hash_algos")
-			    && function_exists("openssl_random_pseudo_bytes")
-			    && in_array("sha512", hash_algos())) {
-				$token = hash("sha512", openssl_random_pseudo_bytes ($randLength));
+			if (function_exists("random_bytes")) {
+				$token = bin2hex(random_bytes($randLength));
+			} elseif (function_exists("openssl_random_pseudo_bytes")) {
+				$token = bin2hex(openssl_random_pseudo_bytes($randLength));
 			} else {
 				$token = '';
 				for ($i = 0; $i < 128; ++$i) {

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -356,10 +356,12 @@ class csrfp_test extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($token1 == $token2);
         $this->assertEquals(strlen($token1), 20);
+        $this->assertRegExp('/^[a-z0-9]{20}$/', $token1);
 
         csrfprotector::$config['tokenLength'] = 128;
         $token = csrfprotector::generateAuthToken();
         $this->assertEquals(strlen($token), 128);
+        $this->assertRegExp('/^[a-z0-9]{128}$/', $token);
     }
 
     /**


### PR DESCRIPTION
Auth token creation order is now random_bytes -> openssl_random_pseudo_bytes -> mt_rand.
SHA-512 is unnecessary as we can use bin2hex directly, but $randLength needs to be set to 64.