### PR TITLE
Fix to issue #80

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,18 @@ php:
   - "5.6"
   - "5.5"
   - "5.4"
-  - "5.3"
   - "7.0"
   - "7.1"
   - hhvm
   - nightly
+  - "5.3"
+
 
 matrix:
     allow_failures:
     - php: nightly
     - php: hhvm
+    - php: "5.3"
 
 os:
   - linux

--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -289,55 +289,18 @@ function csrfprotector_init() {
 	 */
 	function new_send(data) {
 		if (this.method.toLowerCase() === 'post') {
-			if (data !== null && typeof data === 'object') {
-				data[CSRFP.CSRFP_TOKEN] = CSRFP._getAuthKey();
-			} else {
-				// Added support for content type == application / json
-				if (this.headers && 'Content-Type' in this.headers
-					&& this.headers['Content-Type'] === 'application/json') {
-					try {
-						data = JSON.parse(data)
-						data[CSRFP.CSRFP_TOKEN] = CSRFP._getAuthKey();
-						return this.old_send(JSON.stringify(data));
-						
-					} catch (ex) {
-						console.log("[ERROR] [CSRF Protector] Unable to parse content ",
-							"when content-type is application/json", ex);
-					}
-				}
-
-				if (typeof data != "undefined") {
-					data += "&";
-				} else {
-					data = "";
-				}
-				data += CSRFP.CSRFP_TOKEN +"=" +CSRFP._getAuthKey();
-			}
+			// attach the token in request header
+			this.setRequestHeader(CSRFP.CSRFP_TOKEN, CSRFP._getAuthKey());
 		}
 		return this.old_send(data);
-	}
-
-	/**
-	 * Wrapper method to override setRequestHeader method of
-	 * XMLHttpRequests
-	 * @param: header - header name
-	 * @param: value - header value
-	 */
-	function new_setRequestHeader(header, value) {
-		if (!this.headers) this.headers = {};
-		this.headers[header] = value;
-
-		this.old_setRequestHeader(header, value);
 	}
 
 	if (window.XMLHttpRequest) {
 		// Wrapping
 		XMLHttpRequest.prototype.old_send = XMLHttpRequest.prototype.send;
 		XMLHttpRequest.prototype.old_open = XMLHttpRequest.prototype.open;
-		XMLHttpRequest.prototype.old_setRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
 		XMLHttpRequest.prototype.open = new_open;
 		XMLHttpRequest.prototype.send = new_send;
-		XMLHttpRequest.prototype.setRequestHeader = new_setRequestHeader;
 	}
 	if (typeof ActiveXObject !== 'undefined') {
 		ActiveXObject.prototype.old_send = ActiveXObject.prototype.send;

--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -290,8 +290,22 @@ function csrfprotector_init() {
 	function new_send(data) {
 		if (this.method.toLowerCase() === 'post') {
 			if (data !== null && typeof data === 'object') {
-				data.append(CSRFP.CSRFP_TOKEN, CSRFP._getAuthKey());
+				data[CSRFP.CSRFP_TOKEN] = CSRFP._getAuthKey();
 			} else {
+				// Added support for content type == application / json
+				if (this.headers && 'Content-Type' in this.headers
+					&& this.headers['Content-Type'] === 'application/json') {
+					try {
+						data = JSON.parse(data)
+						data[CSRFP.CSRFP_TOKEN] = CSRFP._getAuthKey();
+						return this.old_send(JSON.stringify(data));
+						
+					} catch (ex) {
+						console.log("[ERROR] [CSRF Protector] Unable to parse content ",
+							"when content-type is application/json", ex);
+					}
+				}
+
 				if (typeof data != "undefined") {
 					data += "&";
 				} else {
@@ -303,12 +317,27 @@ function csrfprotector_init() {
 		return this.old_send(data);
 	}
 
+	/**
+	 * Wrapper method to override setRequestHeader method of
+	 * XMLHttpRequests
+	 * @param: header - header name
+	 * @param: value - header value
+	 */
+	function new_setRequestHeader(header, value) {
+		if (!this.headers) this.headers = {};
+		this.headers[header] = value;
+
+		this.old_setRequestHeader(header, value);
+	}
+
 	if (window.XMLHttpRequest) {
 		// Wrapping
 		XMLHttpRequest.prototype.old_send = XMLHttpRequest.prototype.send;
 		XMLHttpRequest.prototype.old_open = XMLHttpRequest.prototype.open;
+		XMLHttpRequest.prototype.old_setRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
 		XMLHttpRequest.prototype.open = new_open;
 		XMLHttpRequest.prototype.send = new_send;
+		XMLHttpRequest.prototype.setRequestHeader = new_setRequestHeader;
 	}
 	if (typeof ActiveXObject !== 'undefined') {
 		ActiveXObject.prototype.old_send = ActiveXObject.prototype.send;

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -350,11 +350,10 @@ class csrfp_test extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * test authorise success
+     * test authorise success with token in $_POST
      */
     public function testAuthorisePost_success()
     {
-
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST[csrfprotector::$config['CSRFP_TOKEN']]
             = $_GET[csrfprotector::$config['CSRFP_TOKEN']]
@@ -380,6 +379,34 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
         $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later
+    }
+
+    /**
+     * test authorise success with token in header
+     */
+    public function testAuthorisePost_success_2()
+    {
+        unset($_POST[csrfprotector::$config['CSRFP_TOKEN']]);
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $serverKey = 'HTTP_' .strtoupper(csrfprotector::$config['CSRFP_TOKEN']);
+        $serverKey = str_replace('-', '_', $serverKey);
+
+        $csrfp = new csrfProtector;
+        $reflection = new \ReflectionClass(get_class($csrfp));
+        $property = $reflection->getProperty('tokenHeaderKey');
+        $property->setAccessible(true);
+        // change value to false
+        $property->setValue($csrfp, $serverKey);
+
+        $_SERVER[$serverKey] = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0];
+        $temp = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']];
+
+        csrfprotector::authorizePost(); //will create new session and cookies
+        $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]);
+        $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
+        $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
+        // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later
+ 
     }
 
     /**


### PR DESCRIPTION
https://github.com/mebjas/CSRF-Protector-PHP/issues/80

Changing transport of token in case of `XHR POST` to request header. On server side, for each POST request the library checks for token  in POST payload then in request.