### PR TITLE
path, domain and secure parameters of setcookie method made configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,18 @@ php:
   - "5.6"
   - "5.5"
   - "5.4"
-  - "5.3"
   - "7.0"
   - "7.1"
   - hhvm
   - nightly
+  - "5.3"
+
 
 matrix:
     allow_failures:
     - php: nightly
     - php: hhvm
+    - php: "5.3"
 
 os:
   - linux

--- a/libs/README.md
+++ b/libs/README.md
@@ -15,6 +15,6 @@ CSRFProtector configuration
  - `customErrorMessage`: **Error Message** to be shown to user. Only this text will be shown!<br>**Default: null**
  - `jsUrl`: **Absolute url** of the js file. (See [Setting up](https://github.com/mebjas/CSRF-Protector-PHP/wiki/Setting-up-CSRF-Protector-PHP-in-your-web-application) for more information)
  - `tokenLength`: length of csrfp token, Default `10`
- - `cookieConfig`: Array of parameter values for set cookie method.  supports three properties: `path`, `domain`, `secure`. They have same meaning as respective parameters of `setcookie` method in php have: [learn more - php.net]
+ - `cookieConfig`: Array of parameter values for set cookie method.  supports three properties: `path`, `domain`, `secure`. They have same meaning as respective parameters of `setcookie` method: [learn more - php.net]
  - `disabledJavascriptMessage`: messaged to be shown if js is disabled (string)
  - `verifyGetFor`: regex rules for those urls for which csrfp validation should be enabled for `GET` requests also. (View [verifyGetFor rules](https://github.com/mebjas/CSRF-Protector-PHP/wiki/verifyGetFor-rules) for more information)

--- a/libs/README.md
+++ b/libs/README.md
@@ -15,6 +15,6 @@ CSRFProtector configuration
  - `customErrorMessage`: **Error Message** to be shown to user. Only this text will be shown!<br>**Default: null**
  - `jsUrl`: **Absolute url** of the js file. (See [Setting up](https://github.com/mebjas/CSRF-Protector-PHP/wiki/Setting-up-CSRF-Protector-PHP-in-your-web-application) for more information)
  - `tokenLength`: length of csrfp token, Default `10`
- - `secureCookie`: sets the "secure" HTTPS flag on the cookie. <br>**Default: `false`**
+ - `cookieConfig`: Array of parameter values for set cookie method.  supports three properties: `path`, `domain`, `secure`. They have same meaning as respective parameters of `setcookie` method in php have: [learn more - php.net]
  - `disabledJavascriptMessage`: messaged to be shown if js is disabled (string)
  - `verifyGetFor`: regex rules for those urls for which csrfp validation should be enabled for `GET` requests also. (View [verifyGetFor rules](https://github.com/mebjas/CSRF-Protector-PHP/wiki/verifyGetFor-rules) for more information)

--- a/libs/config.sample.php
+++ b/libs/config.sample.php
@@ -17,7 +17,11 @@ return array(
 	"customErrorMessage" => "",
 	"jsUrl" => "",
 	"tokenLength" => 10,
-	"secureCookie" => false,
+	"cookieConfig" => array(
+		"path" => '',
+		"domain" => '',
+		"secure" => false
+	),
 	"disabledJavascriptMessage" => "This site attempts to protect users against <a href=\"https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29\">
 	Cross-Site Request Forgeries </a> attacks. In order to do so, you must have JavaScript enabled in your web browser otherwise this site will fail to work correctly for you.
 	 See details of your web browser for how to enable JavaScript.",

--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -388,11 +388,11 @@ if (!defined('__CSRF_PROTECTOR__')) {
 			if (self::$cookieConfig === null) {
 				if (!isset(self::$config['cookieConfig']))
 					self::$config['cookieConfig'] = array();
-
 				self::$cookieConfig = new cookieConfig(self::$config['cookieConfig']);
 			}
 
-			setcookie(self::$config['CSRFP_TOKEN'], 
+			setcookie(
+				self::$config['CSRFP_TOKEN'], 
 				$token, 
 				time() + self::$cookieExpiryTime,
 				self::$cookieConfig->path,

--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -23,6 +23,47 @@ if (!defined('__CSRF_PROTECTOR__')) {
 	class incompleteConfigurationException extends \exception {};
 	class alreadyInitializedException extends \exception {};
 
+	/**
+	 * Cookie config class
+	 */
+	class cookieConfig
+	{
+		/**
+		 * Variable: $path
+		 * path parameter for setcookie method
+		 * @var string
+		 */
+		public $path = '';
+
+		/**
+		 * Variable: $domain
+		 * domain parameter for setcookie method
+		 * @var string
+		 */
+		public $domain = '';
+
+		/**
+		 * Variable: $secure
+		 * secure parameter for setcookie method
+		 * @var bool
+		 */
+		public $secure = false;
+
+		/**
+		 * Function: constructor
+		 * 
+		 * Parameters:
+		 * $cfg - config array loaded from config file;
+		 */
+		function __construct($cfg) {
+			if ($cfg !== null) {
+				if (isset($cfg['path'])) $this->path = $cfg['path'];
+				if (isset($cfg['domain'])) $this->domain = $cfg['domain'];
+				if (isset($cfg['secure'])) $this->secure = (bool) $cfg['secure'];
+			}
+		}
+	}
+
 	class csrfProtector
 	{
 		/*
@@ -45,6 +86,13 @@ if (!defined('__CSRF_PROTECTOR__')) {
 		 * @var bool
 		 */
 		private static $isValidHTML = false;
+
+		/**
+		 * Variable: $cookieConfig
+		 * Array of parameters for the setcookie method
+		 * @var cookieConfig;
+		 */
+		private static $cookieConfig = null;
 
 		/*
 		 * Variable: $requestType
@@ -139,6 +187,11 @@ if (!defined('__CSRF_PROTECTOR__')) {
 
 			if (self::$config['CSRFP_TOKEN'] == '')
 				self::$config['CSRFP_TOKEN'] = CSRFP_TOKEN;
+
+			// load parameters for setcookie method
+			if (!isset(self::$config['cookieConfig']))
+				self::$config['cookieConfig'] = array();
+			self::$cookieConfig = new cookieConfig(self::$config['cookieConfig']);
 
 			// Validate the config if everythings filled out
 			// TODO: collect all missing values and throw exception together
@@ -328,16 +381,23 @@ if (!defined('__CSRF_PROTECTOR__')) {
 				|| !is_array($_SESSION[self::$config['CSRFP_TOKEN']]))
 				$_SESSION[self::$config['CSRFP_TOKEN']] = array();
 
-			//set token to session for server side validation
+			// set token to session for server side validation
 			array_push($_SESSION[self::$config['CSRFP_TOKEN']], $token);
 
-			//set token to cookie for client side processing
+			// set token to cookie for client side processing
+			if (self::$cookieConfig === null) {
+				if (!isset(self::$config['cookieConfig']))
+					self::$config['cookieConfig'] = array();
+
+				self::$cookieConfig = new cookieConfig(self::$config['cookieConfig']);
+			}
+
 			setcookie(self::$config['CSRFP_TOKEN'], 
 				$token, 
 				time() + self::$cookieExpiryTime,
-				'',
-				'',
-				(array_key_exists('secureCookie', self::$config) ? (bool)self::$config['secureCookie'] : false));
+				self::$cookieConfig->path,
+				self::$cookieConfig->domain,
+				(bool) self::$cookieConfig->secure);
 		}
 
 		/*

--- a/test/config.test.php
+++ b/test/config.test.php
@@ -17,7 +17,11 @@ return array(
 	"customErrorMessage" => "",
 	"jsUrl" => "http://localhost/csrfp/js/csrfprotector.js",
 	"tokenLength" => 10,
-	"secureCookie" => false,
+	"cookieConfig" => array(
+		"path" => '',
+		"domain" => '',
+		"secure" => false
+	),
 	"disabledJavascriptMessage" => "This site attempts to protect users against <a href=\"https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29\">
 	Cross-Site Request Forgeries </a> attacks. In order to do so, you must have JavaScript enabled in your web browser otherwise this site will fail to work correctly for you.
 	 See details of your web browser for how to enable JavaScript.",

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -91,7 +91,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $this->logDir = __DIR__ .'/logs';
 
         csrfprotector::$config['CSRFP_TOKEN'] = 'csrfp_token';
-        csrfprotector::$config['secureCookie'] = false;
+        csrfprotector::$config['cookieConfig'] = array('secure' => false);
         csrfprotector::$config['logDirectory'] = '../test/logs';
 
         $_SERVER['REQUEST_URI'] = 'temp';       // For logging
@@ -143,6 +143,35 @@ class csrfp_test extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Function to check cookieconfig class
+     */
+    public function testCookieConfigClass() {
+        $cfg = array(
+            "path" => "abcd",
+            "secure" => true,
+            "domain" => "abcd",
+        );
+
+        // simple test
+        $cookieConfig = new cookieConfig($cfg);
+        $this->assertEquals($cookieConfig->path, "abcd");
+        $this->assertEquals($cookieConfig->domain, "abcd");
+        $this->assertEquals($cookieConfig->secure, true);
+
+        // default value test
+        $cookieConfig = new cookieConfig(array());
+        $this->assertEquals($cookieConfig->path, '');
+        $this->assertEquals($cookieConfig->domain, '');
+        $this->assertEquals($cookieConfig->secure, false);
+
+        // secure as string
+        $cookieConfig = new cookieConfig(array('secure' => 'true'));
+        $this->assertEquals($cookieConfig->secure, true);
+        $cookieConfig = new cookieConfig(array('secure' => 'false'));
+        $this->assertEquals($cookieConfig->secure, true);
+    }
+
+    /**
      * test secure flag is set in the token cookie when requested
      */
     public function testSecureCookie()
@@ -150,11 +179,11 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SESSION[csrfprotector::$config['CSRFP_TOKEN']] = array('123abcd');
 
-        csrfprotector::$config['secureCookie'] = false;
+        csrfprotector::$config['cookieConfig'] = array('secure' => false);
         csrfprotector::refreshToken();
         $this->assertNotRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
 
-        csrfprotector::$config['secureCookie'] = true;
+        csrfprotector::$config['cookieConfig'] = array('secure' => true);
         csrfprotector::refreshToken();
         $this->assertRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
     }

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -179,16 +179,19 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SESSION[csrfprotector::$config['CSRFP_TOKEN']] = array('123abcd');
 
-        csrfprotector::$config['cookieConfig'] = array('secure' => false);
-        csrfprotector::refreshToken();
-        $this->assertNotRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
-
         // this one would generally fails, as init was already called and now private static
         // property is set with secure as false;
         $csrfp = new csrfProtector;
         $reflection = new \ReflectionClass(get_class($csrfp));
         $property = $reflection->getProperty('cookieConfig');
         $property->setAccessible(true);
+
+        // change value to false
+        $property->setValue($csrfp, new cookieConfig(array('secure' => false)));
+        csrfprotector::refreshToken();
+        $this->assertNotRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
+
+        // change value to true
         $property->setValue($csrfp, new cookieConfig(array('secure' => true)));
         csrfprotector::refreshToken();
         $this->assertRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -183,7 +183,13 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         csrfprotector::refreshToken();
         $this->assertNotRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
 
-        csrfprotector::$config['cookieConfig'] = array('secure' => true);
+        // this one would generally fails, as init was already called and now private static
+        // property is set with secure as false;
+        $csrfp = new csrfProtector;
+        $reflection = new \ReflectionClass(get_class($csrfp));
+        $property = $reflection->getProperty('cookieConfig');
+        $property->setAccessible(true);
+        $property->setValue($csrfp, new cookieConfig(array('secure' => true)));
         csrfprotector::refreshToken();
         $this->assertRegExp('/; secure/', csrfp_wrapper::getHeaderValue('Set-Cookie'));
     }


### PR DESCRIPTION
Based on asks to set path, domain and secure flags while setting cookie, this PR makes these parameters configurable. These can be set in `cookieConfig` key in config.php.

