### PR TITLE
Fix JS regex for looking up csrfp_token value

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -49,7 +49,7 @@ var CSRFP = {
 	 * @return {string|Boolean} csrftoken retrieved from cookie
 	 */
 	_getAuthKey: function() {
-		var re = new RegExp(CSRFP.CSRFP_TOKEN +"=([^;]+)(;|$)");
+		var re = new RegExp("(^|;\s*)"+ CSRFP.CSRFP_TOKEN +"=([^;]+)(;|$)");
 		var RegExpArray = re.exec(document.cookie);
 		
 		if (RegExpArray === null) {


### PR DESCRIPTION
We encountered a customer issue where their iOS devices were hitting a CSRF protector error.

After some debugging, we discovered they were using a feature of the Barracuda Web Application Firewall that signs cookies to prevent user tampering. The signed value is saved in another cookie named `BNES_csrfp_token`. Due to the way the regular expression is written, 