### PR TITLE
Dispatch an event so clients know the library has initialized

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -355,4 +355,8 @@ function csrfprotector_init() {
 
 window.addEventListener("DOMContentLoaded", function() {
 	csrfprotector_init();
+
+    // Dispatch an event so clients know the library has initialized
+    var postCsrfProtectorInit = new Event('postCsrfProtectorInit');
+    window.dispatchEvent(postCsrfProtectorInit);
 }, false);

--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -356,7 +356,7 @@ function csrfprotector_init() {
 window.addEventListener("DOMContentLoaded", function() {
 	csrfprotector_init();
 
-    // Dispatch an event so clients know the library has initialized
-    var postCsrfProtectorInit = new Event('postCsrfProtectorInit');
-    window.dispatchEvent(postCsrfProtectorInit);
+	// Dispatch an event so clients know the library has initialized
+	var postCsrfProtectorInit = new Event('postCsrfProtectorInit');
+	window.dispatchEvent(postCsrfProtectorInit);
 }, false);


### PR DESCRIPTION
Helps with ajax that has to run on page load: window.addEventListener('postCsrfProtectorInit'... can be used to run code as soon as CSRF Protector is initialized