### PR TITLE
Fixed the multi tab issue through unset used token only and set cookie default path `/` to generate new token while ajax calls

### DIFF
--- a/libs/config.sample.php
+++ b/libs/config.sample.php
@@ -18,7 +18,7 @@ return array(
 	"jsUrl" => "",
 	"tokenLength" => 10,
 	"cookieConfig" => array(
-		"path" => '',
+		"path" => '/',
 		"domain" => '',
 		"secure" => false,
 		"expire" => '',

--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -302,10 +302,11 @@ if (!defined('__CSRF_PROTECTOR__')) {
 
                     // Clear all older tokens assuming they have been consumed
                     foreach ($_SESSION[self::$config['CSRFP_TOKEN']] as $_key => $_value) {
-                        if ($_value == $token) break;
-                        array_shift($_SESSION[self::$config['CSRFP_TOKEN']]);
+                        if ($_value == $token) {
+                            unset($_SESSION[self::$config['CSRFP_TOKEN']][$_key]);
+                            return true;
+                        }
                     }
-                    return true;
                 }
             }
 

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -406,7 +406,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         csrfp_wrapper::changeRequestType('GET');
         $_POST[csrfprotector::$config['CSRFP_TOKEN']]
             = $_GET[csrfprotector::$config['CSRFP_TOKEN']]
-            = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0];
+            = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][1];
         $temp = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']];
 
         csrfprotector::authorizePost(); //will create new session and cookies
@@ -437,7 +437,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $temp = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']];
 
         csrfprotector::authorizePost(); //will create new session and cookies
-        $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]);
+        $this->assertTrue(!isset($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
         $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -396,7 +396,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $temp = $_SESSION[csrfprotector::$config['CSRFP_TOKEN']];
 
         csrfprotector::authorizePost(); //will create new session and cookies
-        $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]);
+        $this->assertTrue(!isset($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
         $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later


### PR DESCRIPTION
Fixed the multi tab issue through unset used token only and set cookie default path `/` to generate new token while ajax calls

Reference of issue: https://github.com/mebjas/CSRF-Protector-PHP/issues/116
