### PR TITLE
Use getallheaders() instead of apache_request_headers()

### DIFF
--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -267,10 +267,10 @@ if (!defined('__CSRF_PROTECTOR__')) {
                 return $_POST[self::$config['CSRFP_TOKEN']];
             }
 
-            if (function_exists('apache_request_headers')) {
-                $apacheRequestHeaders = apache_request_headers();
-                if (isset($apacheRequestHeaders[self::$config['CSRFP_TOKEN']])) {
-                    return $apacheRequestHeaders[self::$config['CSRFP_TOKEN']];
+            if (function_exists('getallheaders')) {
+                $requestHeaders = getallheaders();
+                if (isset($requestHeaders[self::$config['CSRFP_TOKEN']])) {
+                    return $requestHeaders[self::$config['CSRFP_TOKEN']];
                 }
             }
 


### PR DESCRIPTION
On Dockerized environment where apache and php are running in separate
containers, there are no `apache_` methods.

The `getallheaders()` method is an alias to the `apache_request_headers()`
method, therefore the behaviour will be identical.  The reason to use the
alias function, eh `getallheaders()` is that there are polyfills to
`getallheaders` function (like  ralouphie/getallheaders used by Guzzle,
very popular HTTP library), but there are no polyfills to the
`apache_request_headers` function.