### PR TITLE
Fix #120 by renaming the csrfp-token to conform to header rules

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -15,7 +15,7 @@ var CSRFP_FIELD_TOKEN_NAME = 'csrfp_hidden_data_token';
 var CSRFP_FIELD_URLS = 'csrfp_hidden_data_urls';
 
 var CSRFP = {
-	CSRFP_TOKEN: 'csrfp_token',
+	CSRFP_TOKEN: 'CSRFP-Token',
 	/**
 	 * Array of patterns of url, for which csrftoken need to be added
 	 * In case of GET request also, provided from server
@@ -130,7 +130,7 @@ var CSRFP = {
 			// Trigger the functions
 			var result = fun.apply(this, [event]);
 			
-			// Now append the csrfp_token back
+			// Now append the CSRFP-Token back
 			obj.appendChild(CSRFP._getInputElt());
 			
 			return result;

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,7 +1,7 @@
 CSRFProtector configuration
 ==========================================
 
- - `CSRFP_TOKEN`: name of the csrf nonce, used for cookie or posting as argument. default: `csrfp_token` (if left blank)
+ - `CSRFP_TOKEN`: name of the csrf nonce, used for cookie or posting as argument. default: `CSRFP-Token` (if left blank)
  - `logDirectory`: location of the directory at which log files will be saved, either **relative** to the default `config.php` file location or an **absolute** path. This is required for file based logging (default), Not needed, in case you override logging function to implement your logging logic. (View [Overriding logging function](https://github.com/mebjas/CSRF-Protector-PHP/wiki/Overriding-logging-function))
  <br>**Default value:** `../log/`
  - `failedAuthAction`: Action code (integer) for action to be taken in case of failed validation. Has two different values for bot `GET` and `POST`. Different action codes are specified as follows, (<br>**Default:** `0` for both `GET` & `POST`):

--- a/libs/csrf/csrfprotector.php
+++ b/libs/csrf/csrfprotector.php
@@ -11,7 +11,7 @@ if (!defined('__CSRF_PROTECTOR__')) {
     define('__CSRF_PROTECTOR__', true);         // to avoid multiple declaration errors
 
     // name of HTTP POST variable for authentication
-    define("CSRFP_TOKEN","csrfp_token");
+    define("CSRFP_TOKEN","CSRFP-Token");
 
     // We insert token name and list of url patterns for which
     // GET requests are validated against CSRF as hidden input fields

--- a/test/config.test.php
+++ b/test/config.test.php
@@ -8,7 +8,7 @@
  * ---- tokenLength
  */
 return array(
-	"CSRFP_TOKEN" => "csrfp_token",
+	"CSRFP_TOKEN" => "CSRFP-Token",
 	"logDirectory" => "../log",
 	"failedAuthAction" => array(
 		"GET" => 0,

--- a/test/config.testInit_incompleteConfigurationException.php
+++ b/test/config.testInit_incompleteConfigurationException.php
@@ -8,7 +8,7 @@
  * ---- tokenLength
  */
 return array(
-	"CSRFP_TOKEN" => "csrfp_token",
+	"CSRFP_TOKEN" => "CSRFP-Token",
 //	"logDirectory" => "../log",
 //	"failedAuthAction" => array(
 //		"GET" => 0,

--- a/test/config.testInit_withoutInjectedCSRFGuardScript.php
+++ b/test/config.testInit_withoutInjectedCSRFGuardScript.php
@@ -8,7 +8,7 @@
  * ---- tokenLength
  */
 return array(
-	"CSRFP_TOKEN" => "csrfp_token",
+	"CSRFP_TOKEN" => "CSRFP-Token",
 	"logDirectory" => "../log",
 	"failedAuthAction" => array(
 		"GET" => 0,

--- a/test/csrfprotector_test.php
+++ b/test/csrfprotector_test.php
@@ -96,7 +96,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
     {
         $this->logDir = __DIR__ .'/logs';
 
-        csrfprotector::$config['CSRFP_TOKEN'] = 'csrfp_token';
+        csrfprotector::$config['CSRFP_TOKEN'] = 'CSRFP-Token';
         csrfprotector::$config['cookieConfig'] = array('secure' => false);
         csrfprotector::$config['logDirectory'] = '../test/logs';
 
@@ -144,7 +144,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         $this->assertTrue(strcmp($val, $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][1]) != 0);
 
         $this->assertTrue(csrfP_wrapper::checkHeader('Set-Cookie'));
-        $this->assertTrue(csrfP_wrapper::checkHeader('csrfp_token'));
+        $this->assertTrue(csrfP_wrapper::checkHeader('CSRFP-Token'));
         $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][1]));
     }
 
@@ -398,7 +398,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         csrfprotector::authorizePost(); //will create new session and cookies
         $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]);
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
-        $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
+        $this->assertTrue(csrfp_wrapper::checkHeader('CSRFP-Token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later
 
         // For get method
@@ -412,7 +412,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         csrfprotector::authorizePost(); //will create new session and cookies
         $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']]);
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
-        $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
+        $this->assertTrue(csrfp_wrapper::checkHeader('CSRFP-Token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later
     }
 
@@ -439,7 +439,7 @@ class csrfp_test extends PHPUnit_Framework_TestCase
         csrfprotector::authorizePost(); //will create new session and cookies
         $this->assertFalse($temp == $_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]);
         $this->assertTrue(csrfp_wrapper::checkHeader('Set-Cookie'));
-        $this->assertTrue(csrfp_wrapper::checkHeader('csrfp_token'));
+        $this->assertTrue(csrfp_wrapper::checkHeader('CSRFP-Token'));
         // $this->assertTrue(csrfp_wrapper::checkHeader($_SESSION[csrfprotector::$config['CSRFP_TOKEN']][0]));  // Combine these 3 later
  
     }

--- a/test/csrfprotector_test_customlogger.php
+++ b/test/csrfprotector_test_customlogger.php
@@ -24,7 +24,7 @@ class csrfp_test_customLogger extends PHPUnit_Framework_TestCase
     protected $config = array();
 
     public function setUp() {
-        csrfprotector::$config['CSRFP_TOKEN'] = 'csrfp_token';
+        csrfprotector::$config['CSRFP_TOKEN'] = 'CSRFP-Token';
         csrfprotector::$config['cookieConfig'] = array('secure' => false);
         csrfprotector::$config['logDirectory'] = '../test/logs';
         $_SERVER['REQUEST_URI'] = 'temp';       // For logging


### PR DESCRIPTION
Both Nginx and Apache2.4 treat the headers with underscore as invalid.
As a solution lets rename the token name to CSRFP-Token that should be
valid for cookie,get and headers.

Issue: #120