### PR TITLE
Continue inside eventlistener function does not work, causes Syntax E…

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -307,7 +307,7 @@ function csrfprotector_init() {
 		document.links[i].addEventListener("mousedown", function (event) {
 			var href = event.target.href;
 			if (typeof href !== "string") {
-				continue;
+				return;
 			}
 			var urlParts = href.split('#');
 			var url = urlParts[0];


### PR DESCRIPTION
`continue` inside eventlistener function does not work, causes Syntax Error on Firefox.

- Replacing continue with return inside mousedown listeners.

This solves an issue on Firefox where CSRF-Protector-PHP would always return 403 due to this javascript SyntaxError.

