### PR TITLE
Make regex to find cookie value more restrictive

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -44,7 +44,7 @@ var CSRFP = {
 	 * @return {String} auth key from cookie.
 	 */
 	_getAuthKey: function () {
-		var regex = new RegExp(`${CSRFP.CSRFP_TOKEN}=([^;]+)(;|$)`);
+		var regex = new RegExp(`(?:^|;\s*)${CSRFP.CSRFP_TOKEN}=([^;]+)(;|$)`);
 		var regexResult = regex.exec(document.cookie);
 		if (regexResult === null) {
 			return null;


### PR DESCRIPTION
The Javascript library searches `document.cookie` to find the CSRF token
value associated with the cookie named after the constant `CSRFP_TOKEN`
(in practice, this is `csrfp_token`). However, the regex does not define
what values may precede the token's name, meaning that a cookie such as
`BNES_csrfp_token` (as was set by the Barracuda WAF) set on the same
domain can be erroneously picked up instead of the correct `csrfp_token`
value.

This commit restricts the regex to only match if it is preceded by
either the start of the string (i.e. nothing) or a semicolon followed by
(a) any amount of whitespace, or (b) nothing, followed by the cookie's
name. This allows it to match if it is the only/first cookie in
`document.cookie` as well as if it follows another cookie in
`document.cookie`.