### PR TITLE
Regex fix that failed to load cookie from store.

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -44,7 +44,7 @@ var CSRFP = {
 	 * @return {String} auth key from cookie.
 	 */
 	_getAuthKey: function () {
-		var regex = new RegExp(`(?:^|;\s*)${CSRFP.CSRFP_TOKEN}=([^;]+)(;|$)`);
+		var regex = new RegExp(`(?:^|;\s*|; \s*)${CSRFP.CSRFP_TOKEN}=([^;]+)(;|$)`);
 		var regexResult = regex.exec(document.cookie);
 		if (regexResult === null) {
 			return null;


### PR DESCRIPTION
The regex did not take into account that spaces around the cookie entries are possible.
This fix remedies that by expanding the regex rule in the javascript.
Further documentation: https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie