### PR TITLE
Re-assigning forms actions

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -232,6 +232,16 @@ function csrfprotector_init() {
 			}
 		}
 	}
+	
+	//reassign every form functions 
+	for (let form of document.forms){
+		form.submit = HTMLFormElement.prototype.submit
+		form.submit_real = HTMLFormElement.prototype.submit_real
+		form.attachEvent = HTMLFormElement.prototype.attachEvent
+		form.attachEvent_real = HTMLFormElement.prototype.attachEvent_real
+		form.addEventListener = HTMLFormElement.prototype.addEventListener
+		form.addEventListener_real = HTMLFormElement.prototype.addEventListener_real
+	}
 
 	//==================================================================
 	// Wrapper for XMLHttpRequest & ActiveXObject (for IE 6 & below)


### PR DESCRIPTION
This should fix  #147 

this change is needed if submit actions are redefined otherwise createHiddenInputElement() will not be called on submit