### PR TITLE
Fix regex to find token in cookie

### DIFF
--- a/js/csrfprotector.js
+++ b/js/csrfprotector.js
@@ -44,7 +44,7 @@ var CSRFP = {
 	 * @return {String} auth key from cookie.
 	 */
 	_getAuthKey: function () {
-		var regex = new RegExp(`(?:^|;\s*)${CSRFP.CSRFP_TOKEN}=([^;]+)(;|$)`);
+		var regex = new RegExp(`(?:^|;\\s*)${CSRFP.CSRFP_TOKEN}=([^;]+)(;|$)`);
 		var regexResult = regex.exec(document.cookie);
 		if (regexResult === null) {
 			return null;


### PR DESCRIPTION
In the case when the CSRFP token is not at the beginning of the cookie header, the current regex will fail to detect the token correctly because of wrong slash escape in expression.